### PR TITLE
ENT-253: local Codex cost guide and 5.4 pricing aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ AI coding assistants are becoming essential development tools, but understanding
 - [Import Command](docs/import.md) — Import historical session data from local AI tool files
 - [Export Command](docs/export.md) — Export telemetry data to Parquet files for archiving and sharing
 - [Pricing System](docs/pricing.md) — Cost calculation for Claude, Codex, and Gemini models
+- [Local Codex Cost Guide](docs/codex-local-cost-guide.md) — Start AI Observer locally and import Codex cost data
 
 ## Screenshots
 

--- a/backend/internal/pricing/data/codex.json
+++ b/backend/internal/pricing/data/codex.json
@@ -3,6 +3,7 @@
   "lastUpdated": "2026-01-02T00:00:00Z",
   "models": {
     "gpt-5": {
+      "aliases": ["gpt-5.4"],
       "inputCostPerMTok": 1.25,
       "outputCostPerMTok": 10,
       "cacheReadCostPerMTok": 0.125
@@ -18,6 +19,7 @@
       "cacheReadCostPerMTok": 0.175
     },
     "gpt-5-mini": {
+      "aliases": ["gpt-5.4-mini"],
       "inputCostPerMTok": 0.25,
       "outputCostPerMTok": 2,
       "cacheReadCostPerMTok": 0.025

--- a/backend/internal/pricing/pricing_test.go
+++ b/backend/internal/pricing/pricing_test.go
@@ -202,6 +202,19 @@ func TestNormalizeCodexModel(t *testing.T) {
 	}
 }
 
+func TestCodexAliasLookup(t *testing.T) {
+	tests := []string{"gpt-5.4", "gpt-5.4-mini"}
+	for _, alias := range tests {
+		pricing := GetCodexPricing(alias)
+		if pricing == nil {
+			t.Fatalf("Codex alias %s not resolved", alias)
+		}
+		if pricing.InputCostPerToken <= 0 {
+			t.Fatalf("Codex alias %s has invalid input cost: %v", alias, pricing.InputCostPerToken)
+		}
+	}
+}
+
 func TestNormalizeClaudeModel(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/docs/codex-local-cost-guide.md
+++ b/docs/codex-local-cost-guide.md
@@ -1,0 +1,64 @@
+# Local Codex Cost Guide
+
+This guide shows how to run AI Observer locally and import Codex telemetry so cost data appears in the dashboard.
+
+## Prerequisites
+
+- `ai-observer` installed locally
+- `Codex` sessions available under `~/.codex`
+
+## Start AI Observer
+
+Run the server against a local DuckDB file:
+
+```bash
+mkdir -p ./data
+AI_OBSERVER_DATABASE_PATH=./data/ai-observer.duckdb \
+AI_OBSERVER_API_PORT=8080 \
+AI_OBSERVER_OTLP_PORT=4318 \
+ai-observer
+```
+
+Open the dashboard at:
+
+```text
+http://localhost:8080
+```
+
+## Import Codex Cost Data
+
+Import Codex sessions and recalculate cost rows:
+
+```bash
+ai-observer import codex --force --yes
+```
+
+Notes:
+
+- `--force` is important when you want to recalculate cost after pricing changes.
+- The importer deduplicates by file path and content hash unless you use `--force`.
+- Codex cost is calculated from token usage and the built-in pricing table.
+
+## Verify Cost
+
+Check that the Codex cost metric exists:
+
+```bash
+curl 'http://localhost:8080/api/metrics/names?service=codex_cli_rs'
+```
+
+Check the cost series:
+
+```bash
+curl 'http://localhost:8080/api/metrics/series?name=codex_cli_rs.cost.usage&service=codex_cli_rs&from=2026-03-19T00:00:00Z&to=2026-03-20T00:00:00Z&interval=3600&aggregate=true'
+```
+
+## Supported Models
+
+Supported Codex model pricing lives in:
+
+```text
+backend/internal/pricing/data/codex.json
+```
+
+If a Codex model slug is not priced yet, the cost metric may stay empty until the table is updated and the Codex import is rerun.


### PR DESCRIPTION
This adds a small self-service guide for running AI Observer locally and importing Codex cost data, plus Codex 5.4 pricing aliases so cost rows populate for newer model slugs.

Benefit: teammates can launch the observer and refresh Codex cost data without needing a handoff, which speeds up troubleshooting and repeat validation.

Validation:
- `cd backend && go test ./internal/pricing`
- `semgrep --config auto /tmp/ai-observer/backend/internal/pricing /tmp/ai-observer/docs`
