### PR TITLE
feat(import): enrich Claude Code import with git/PR metadata and new metrics

### DIFF
--- a/backend/internal/importer/claude.go
+++ b/backend/internal/importer/claude.go
@@ -102,7 +102,7 @@ func (p *ClaudeParser) FindSessionFiles(ctx context.Context) ([]string, error) {
 
 // claudeJSONLEntry represents a single line in Claude Code JSONL files
 type claudeJSONLEntry struct {
-	Type      string         `json:"type,omitempty"` // Root type: "assistant", "user", "queue-operation", etc.
+	Type      string         `json:"type,omitempty"` // Root type: "assistant", "user", "pr-link", "system", etc.
 	Timestamp string         `json:"timestamp"`
 	SessionID string         `json:"sessionId,omitempty"`
 	Version   string         `json:"version,omitempty"`
@@ -110,6 +110,14 @@ type claudeJSONLEntry struct {
 	RequestID string         `json:"requestId,omitempty"`
 	CostUSD   *float64       `json:"costUSD,omitempty"`
 	Message   *claudeMessage `json:"message,omitempty"`
+	GitBranch string         `json:"gitBranch,omitempty"`
+	// PR link fields (present when type == "pr-link")
+	PRNumber     int    `json:"prNumber,omitempty"`
+	PRUrl        string `json:"prUrl,omitempty"`
+	PRRepository string `json:"prRepository,omitempty"`
+	// System entry fields (present when type == "system")
+	Subtype    string  `json:"subtype,omitempty"`
+	DurationMs float64 `json:"durationMs,omitempty"`
 }
 
 type claudeMessage struct {
@@ -137,6 +145,92 @@ type claudeUsage struct {
 	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 }
 
+// claudeEditInput holds the input for Edit tool calls
+type claudeEditInput struct {
+	FilePath  string `json:"file_path"`
+	OldString string `json:"old_string"`
+	NewString string `json:"new_string"`
+}
+
+// claudeWriteInput holds the input for Write tool calls
+type claudeWriteInput struct {
+	FilePath string `json:"file_path"`
+	Content  string `json:"content"`
+}
+
+// claudeMultiEditInput holds the input for MultiEdit tool calls
+type claudeMultiEditInput struct {
+	FilePath string `json:"file_path"`
+	Edits    []struct {
+		OldString string `json:"old_string"`
+		NewString string `json:"new_string"`
+	} `json:"edits"`
+}
+
+// claudeSessionMeta holds session-level metadata collected in a first pass
+type claudeSessionMeta struct {
+	GitBranch    string
+	Cwd          string
+	PRNumber     int
+	PRUrl        string
+	PRRepository string
+	PRTimestamp  time.Time
+}
+
+// collectSessionMeta does a first pass over raw JSONL lines to collect session-level metadata
+func (p *ClaudeParser) collectSessionMeta(lines []string) claudeSessionMeta {
+	meta := claudeSessionMeta{}
+	seenPRs := make(map[int]bool)
+
+	for _, line := range lines {
+		var entry claudeJSONLEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry.GitBranch != "" && meta.GitBranch == "" {
+			meta.GitBranch = entry.GitBranch
+		}
+		if entry.Cwd != "" && meta.Cwd == "" {
+			meta.Cwd = entry.Cwd
+		}
+		if entry.Type == "pr-link" && entry.PRNumber != 0 && !seenPRs[entry.PRNumber] {
+			seenPRs[entry.PRNumber] = true
+			// Use the first PR linked in the session
+			if meta.PRNumber == 0 {
+				meta.PRNumber = entry.PRNumber
+				meta.PRUrl = entry.PRUrl
+				meta.PRRepository = entry.PRRepository
+				if ts, err := time.Parse(time.RFC3339Nano, entry.Timestamp); err == nil {
+					meta.PRTimestamp = ts
+				} else if ts, err := time.Parse(time.RFC3339, entry.Timestamp); err == nil {
+					meta.PRTimestamp = ts
+				}
+			}
+		}
+	}
+	return meta
+}
+
+// extractRepository returns a repository identifier from session metadata.
+// Uses prRepository if set (e.g. "org/repo"), otherwise derives from the last cwd component.
+func extractRepository(meta claudeSessionMeta) string {
+	if meta.PRRepository != "" {
+		return meta.PRRepository
+	}
+	if meta.Cwd != "" {
+		return filepath.Base(meta.Cwd)
+	}
+	return ""
+}
+
+// countLines returns the number of lines in s (at least 1 for non-empty strings)
+func countLines(s string) int {
+	if s == "" {
+		return 0
+	}
+	return strings.Count(s, "\n") + 1
+}
+
 // ParseFile parses a Claude Code JSONL file
 func (p *ClaudeParser) ParseFile(ctx context.Context, path string) (*ImportResult, error) {
 	file, err := os.Open(path)
@@ -158,24 +252,59 @@ func (p *ClaudeParser) ParseFile(ctx context.Context, path string) (*ImportResul
 	buf := make([]byte, 0, 64*1024)
 	scanner.Buffer(buf, 1024*1024)
 
-	lineNum := 0
-	messageIndex := 0                     // Track message order for transcripts
-	seenRequests := make(map[string]bool) // For deduplication of metrics
-
+	// Collect all non-empty lines
+	var lines []string
 	for scanner.Scan() {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
+		if line := scanner.Text(); strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading file: %w", err)
+	}
 
-		lineNum++
-		line := scanner.Text()
-		if strings.TrimSpace(line) == "" {
-			continue
+	// First pass: collect session-level metadata (gitBranch, PR info, cwd)
+	meta := p.collectSessionMeta(lines)
+	repository := extractRepository(meta)
+
+	// Emit pull_request.count metric if a PR was linked
+	if meta.PRNumber != 0 && !meta.PRTimestamp.IsZero() {
+		result.Metrics = append(result.Metrics, createPRMetric(meta, repository))
+	}
+
+	messageIndex := 0
+	seenRequests := make(map[string]bool) // For deduplication of metrics
+
+	// Second pass: process records
+	for _, line := range lines {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
 		}
 
 		var entry claudeJSONLEntry
 		if err := json.Unmarshal([]byte(line), &entry); err != nil {
-			// Skip malformed lines
+			continue
+		}
+
+		// Handle system/turn_duration entries for active time (no message field)
+		if entry.Type == "system" && entry.Subtype == "turn_duration" && entry.DurationMs > 0 {
+			ts, err := time.Parse(time.RFC3339Nano, entry.Timestamp)
+			if err != nil {
+				ts, err = time.Parse(time.RFC3339, entry.Timestamp)
+			}
+			if err == nil {
+				if result.FirstTime.IsZero() || ts.Before(result.FirstTime) {
+					result.FirstTime = ts
+				}
+				if ts.After(result.LastTime) {
+					result.LastTime = ts
+				}
+				secs := entry.DurationMs / 1000.0
+				result.Metrics = append(result.Metrics, createActiveTimeMetric(ts, secs, meta, repository))
+			}
 			continue
 		}
 
@@ -216,11 +345,11 @@ func (p *ClaudeParser) ParseFile(ctx context.Context, path string) (*ImportResul
 		}
 
 		// Create transcript log records from message content
-		transcriptLogs := p.createTranscriptLogs(entry, ts, sessionID, &messageIndex)
+		transcriptLogs := p.createTranscriptLogs(entry, ts, sessionID, meta, &messageIndex)
 		result.Logs = append(result.Logs, transcriptLogs...)
 
-		// For assistant entries with usage data, also create metrics
-		if entry.Type == "assistant" && entry.Message.Usage != nil {
+		// For assistant entries: create metrics and process file-editing tool calls
+		if entry.Type == "assistant" {
 			// Deduplication using messageId:requestId for metrics only
 			dedupKey := fmt.Sprintf("%s:%s", entry.Message.ID, entry.RequestID)
 			if entry.Message.ID != "" && entry.RequestID != "" {
@@ -230,71 +359,197 @@ func (p *ClaudeParser) ParseFile(ctx context.Context, path string) (*ImportResul
 				seenRequests[dedupKey] = true
 			}
 
-			// Create api_request log record (existing behavior)
-			logRecord := api.LogRecord{
-				Timestamp:      ts,
-				ServiceName:    SourceClaude.ServiceName(),
-				SeverityText:   "INFO",
-				SeverityNumber: 9,
-				Body:           "api_request",
-				LogAttributes: map[string]string{
-					"event.name":    "claude_code.api_request",
-					"session.id":    sessionID,
-					"model":         entry.Message.Model,
-					"import_source": "local_jsonl",
-				},
-			}
-			if entry.Cwd != "" {
-				logRecord.LogAttributes["cwd"] = entry.Cwd
-			}
-			if entry.RequestID != "" {
-				logRecord.LogAttributes["request_id"] = entry.RequestID
-			}
-			result.Logs = append(result.Logs, logRecord)
+			// Lines of code from file-editing tool calls
+			locMetrics := p.extractLinesOfCodeMetrics(entry, ts, meta, repository)
+			result.Metrics = append(result.Metrics, locMetrics...)
 
-			// Create metrics
-			usage := entry.Message.Usage
-			model := entry.Message.Model
+			// Commits from Bash tool calls
+			commitMetrics := p.extractCommitMetrics(entry, ts, meta, repository)
+			result.Metrics = append(result.Metrics, commitMetrics...)
 
-			// Token usage metrics (creates both regular and user-facing variants)
-			if usage.InputTokens > 0 {
-				result.Metrics = append(result.Metrics, createTokenMetrics(ts, model, "input", float64(usage.InputTokens))...)
-			}
-			if usage.OutputTokens > 0 {
-				result.Metrics = append(result.Metrics, createTokenMetrics(ts, model, "output", float64(usage.OutputTokens))...)
-			}
-			if usage.CacheCreationInputTokens > 0 {
-				result.Metrics = append(result.Metrics, createTokenMetrics(ts, model, "cacheCreation", float64(usage.CacheCreationInputTokens))...)
-			}
-			if usage.CacheReadInputTokens > 0 {
-				result.Metrics = append(result.Metrics, createTokenMetrics(ts, model, "cacheRead", float64(usage.CacheReadInputTokens))...)
-			}
+			if entry.Message.Usage != nil {
+				// Create api_request log record
+				logRecord := api.LogRecord{
+					Timestamp:      ts,
+					ServiceName:    SourceClaude.ServiceName(),
+					SeverityText:   "INFO",
+					SeverityNumber: 9,
+					Body:           "api_request",
+					LogAttributes: map[string]string{
+						"event.name":    "claude_code.api_request",
+						"session.id":    sessionID,
+						"model":         entry.Message.Model,
+						"import_source": "local_jsonl",
+					},
+				}
+				if entry.Cwd != "" {
+					logRecord.LogAttributes["cwd"] = entry.Cwd
+				}
+				if entry.RequestID != "" {
+					logRecord.LogAttributes["request_id"] = entry.RequestID
+				}
+				if meta.GitBranch != "" {
+					logRecord.LogAttributes["git_branch"] = meta.GitBranch
+				}
+				if repository != "" {
+					logRecord.LogAttributes["repository"] = repository
+				}
+				result.Logs = append(result.Logs, logRecord)
 
-			// Cost metrics using pricing mode (creates both regular and user-facing variants)
-			tokenUsage := pricing.ClaudeTokenUsage{
-				InputTokens:              int64(usage.InputTokens),
-				OutputTokens:             int64(usage.OutputTokens),
-				CacheCreationInputTokens: int64(usage.CacheCreationInputTokens),
-				CacheReadInputTokens:     int64(usage.CacheReadInputTokens),
-			}
-			cost := pricing.GetClaudeCostWithMode(p.pricingMode, model, tokenUsage, entry.CostUSD)
-			if cost > 0 {
-				result.Metrics = append(result.Metrics, createCostMetrics(ts, model, cost)...)
+				// Token usage metrics
+				usage := entry.Message.Usage
+				model := entry.Message.Model
+
+				if usage.InputTokens > 0 {
+					result.Metrics = append(result.Metrics, createTokenMetrics(ts, model, "input", float64(usage.InputTokens), meta, repository)...)
+				}
+				if usage.OutputTokens > 0 {
+					result.Metrics = append(result.Metrics, createTokenMetrics(ts, model, "output", float64(usage.OutputTokens), meta, repository)...)
+				}
+				if usage.CacheCreationInputTokens > 0 {
+					result.Metrics = append(result.Metrics, createTokenMetrics(ts, model, "cacheCreation", float64(usage.CacheCreationInputTokens), meta, repository)...)
+				}
+				if usage.CacheReadInputTokens > 0 {
+					result.Metrics = append(result.Metrics, createTokenMetrics(ts, model, "cacheRead", float64(usage.CacheReadInputTokens), meta, repository)...)
+				}
+
+				// Cost metrics
+				tokenUsage := pricing.ClaudeTokenUsage{
+					InputTokens:              int64(usage.InputTokens),
+					OutputTokens:             int64(usage.OutputTokens),
+					CacheCreationInputTokens: int64(usage.CacheCreationInputTokens),
+					CacheReadInputTokens:     int64(usage.CacheReadInputTokens),
+				}
+				cost := pricing.GetClaudeCostWithMode(p.pricingMode, model, tokenUsage, entry.CostUSD)
+				if cost > 0 {
+					result.Metrics = append(result.Metrics, createCostMetrics(ts, model, cost, meta, repository)...)
+				}
 			}
 		}
 
 		result.RecordCount++
 	}
 
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("reading file: %w", err)
+	// Session count metric — one per file, timestamped at first activity
+	if !result.FirstTime.IsZero() {
+		result.Metrics = append(result.Metrics, createSessionMetric(result.FirstTime, meta, repository))
 	}
 
 	return result, nil
 }
 
+// extractLinesOfCodeMetrics parses file-editing tool calls in an assistant entry and returns
+// claude_code.lines_of_code.count metrics broken down by file type and path.
+func (p *ClaudeParser) extractLinesOfCodeMetrics(entry claudeJSONLEntry, ts time.Time, meta claudeSessionMeta, repository string) []api.MetricDataPoint {
+	var metrics []api.MetricDataPoint
+
+	for _, content := range entry.Message.Content {
+		if content.Type != "tool_use" {
+			continue
+		}
+
+		// Marshal input back to JSON so we can decode into typed structs
+		inputBytes, err := json.Marshal(content.Input)
+		if err != nil {
+			continue
+		}
+
+		switch content.Name {
+		case "Edit":
+			var inp claudeEditInput
+			if err := json.Unmarshal(inputBytes, &inp); err != nil || inp.FilePath == "" {
+				continue
+			}
+			removed := countLines(inp.OldString)
+			added := countLines(inp.NewString)
+			fileType := filepath.Ext(inp.FilePath)
+			relPath := relativeFilePath(inp.FilePath, meta.Cwd)
+			if removed > 0 {
+				metrics = append(metrics, createLOCMetric(ts, "removed", relPath, fileType, float64(removed), meta, repository))
+			}
+			if added > 0 {
+				metrics = append(metrics, createLOCMetric(ts, "added", relPath, fileType, float64(added), meta, repository))
+			}
+
+		case "Write":
+			var inp claudeWriteInput
+			if err := json.Unmarshal(inputBytes, &inp); err != nil || inp.FilePath == "" {
+				continue
+			}
+			added := countLines(inp.Content)
+			fileType := filepath.Ext(inp.FilePath)
+			relPath := relativeFilePath(inp.FilePath, meta.Cwd)
+			if added > 0 {
+				metrics = append(metrics, createLOCMetric(ts, "added", relPath, fileType, float64(added), meta, repository))
+			}
+
+		case "MultiEdit":
+			var inp claudeMultiEditInput
+			if err := json.Unmarshal(inputBytes, &inp); err != nil || inp.FilePath == "" {
+				continue
+			}
+			fileType := filepath.Ext(inp.FilePath)
+			relPath := relativeFilePath(inp.FilePath, meta.Cwd)
+			var totalRemoved, totalAdded int
+			for _, edit := range inp.Edits {
+				totalRemoved += countLines(edit.OldString)
+				totalAdded += countLines(edit.NewString)
+			}
+			if totalRemoved > 0 {
+				metrics = append(metrics, createLOCMetric(ts, "removed", relPath, fileType, float64(totalRemoved), meta, repository))
+			}
+			if totalAdded > 0 {
+				metrics = append(metrics, createLOCMetric(ts, "added", relPath, fileType, float64(totalAdded), meta, repository))
+			}
+		}
+	}
+
+	return metrics
+}
+
+// claudeBashInput holds the input for Bash tool calls
+type claudeBashInput struct {
+	Command string `json:"command"`
+}
+
+// extractCommitMetrics parses Bash tool calls in an assistant entry and returns
+// claude_code.commit.count metrics for git commit commands.
+func (p *ClaudeParser) extractCommitMetrics(entry claudeJSONLEntry, ts time.Time, meta claudeSessionMeta, repository string) []api.MetricDataPoint {
+	var metrics []api.MetricDataPoint
+
+	for _, content := range entry.Message.Content {
+		if content.Type != "tool_use" || content.Name != "Bash" {
+			continue
+		}
+		inputBytes, err := json.Marshal(content.Input)
+		if err != nil {
+			continue
+		}
+		var inp claudeBashInput
+		if err := json.Unmarshal(inputBytes, &inp); err != nil {
+			continue
+		}
+		if strings.Contains(inp.Command, "git commit") {
+			metrics = append(metrics, createCommitMetric(ts, meta, repository))
+		}
+	}
+
+	return metrics
+}
+
+// relativeFilePath returns a path relative to baseDir, falling back to the base filename
+func relativeFilePath(filePath, baseDir string) string {
+	if baseDir == "" {
+		return filepath.Base(filePath)
+	}
+	if rel, err := filepath.Rel(baseDir, filePath); err == nil && !strings.HasPrefix(rel, "..") {
+		return rel
+	}
+	return filepath.Base(filePath)
+}
+
 // createTranscriptLogs creates transcript log records from message content
-func (p *ClaudeParser) createTranscriptLogs(entry claudeJSONLEntry, ts time.Time, sessionID string, messageIndex *int) []api.LogRecord {
+func (p *ClaudeParser) createTranscriptLogs(entry claudeJSONLEntry, ts time.Time, sessionID string, meta claudeSessionMeta, messageIndex *int) []api.LogRecord {
 	var logs []api.LogRecord
 
 	if entry.Message == nil || len(entry.Message.Content) == 0 {
@@ -308,11 +563,11 @@ func (p *ClaudeParser) createTranscriptLogs(entry claudeJSONLEntry, ts time.Time
 		var body string
 		var role string
 		attrs := map[string]string{
-			"event.name":     "transcript.message",
-			"session.id":     sessionID,
-			"message.index":  strconv.Itoa(*messageIndex),
-			"message.role":   baseRole,
-			"import_source":  "local_jsonl",
+			"event.name":    "transcript.message",
+			"session.id":    sessionID,
+			"message.index": strconv.Itoa(*messageIndex),
+			"message.role":  baseRole,
+			"import_source": "local_jsonl",
 		}
 
 		if entry.Message.Model != "" {
@@ -320,6 +575,17 @@ func (p *ClaudeParser) createTranscriptLogs(entry claudeJSONLEntry, ts time.Time
 		}
 		if entry.Message.ID != "" {
 			attrs["message.id"] = entry.Message.ID
+		}
+		if meta.GitBranch != "" {
+			attrs["git_branch"] = meta.GitBranch
+		}
+		if repo := extractRepository(meta); repo != "" {
+			attrs["repository"] = repo
+		}
+		if meta.PRNumber != 0 {
+			attrs["pr_number"] = strconv.Itoa(meta.PRNumber)
+			attrs["pr_repository"] = meta.PRRepository
+			attrs["pr_url"] = meta.PRUrl
 		}
 
 		switch content.Type {
@@ -378,55 +644,147 @@ const (
 	claudeUserFacingTokenUsageMetric = "claude_code.token.usage_user_facing"
 	claudeCostMetric                 = "claude_code.cost.usage"
 	claudeUserFacingCostMetric       = "claude_code.cost.usage_user_facing"
+	claudeLinesOfCodeMetric          = "claude_code.lines_of_code.count"
+	claudePullRequestMetric          = "claude_code.pull_request.count"
+	claudeCommitMetric               = "claude_code.commit.count"
+	claudeSessionMetric              = "claude_code.session.count"
+	claudeActiveTimeMetric           = "claude_code.active_time.total"
 )
 
+// sessionAttrs builds the common session-level attributes (git_branch, repository)
+func sessionAttrs(meta claudeSessionMeta, repository string) map[string]string {
+	attrs := make(map[string]string)
+	if meta.GitBranch != "" {
+		attrs["git_branch"] = meta.GitBranch
+	}
+	if repository != "" {
+		attrs["repository"] = repository
+	}
+	return attrs
+}
+
 // createTokenMetric creates a token usage metric with the specified name
-func createTokenMetric(ts time.Time, metricName, model, tokenType string, value float64) api.MetricDataPoint {
+func createTokenMetric(ts time.Time, metricName, model, tokenType string, value float64, meta claudeSessionMeta, repository string) api.MetricDataPoint {
+	attrs := sessionAttrs(meta, repository)
+	attrs["type"] = tokenType
+	attrs["model"] = model
+	attrs["import_source"] = "local_jsonl"
 	return api.MetricDataPoint{
 		Timestamp:   ts,
 		ServiceName: SourceClaude.ServiceName(),
 		MetricName:  metricName,
 		MetricType:  "sum",
 		Value:       &value,
-		Attributes: map[string]string{
-			"type":          tokenType,
-			"model":         model,
-			"import_source": "local_jsonl",
-		},
+		Attributes:  attrs,
 	}
 }
 
 // createTokenMetrics creates both regular and user-facing token usage metrics.
-// JSONL data is already user-facing (only assistant messages with cache tokens),
-// so both metrics have identical values for consistency with OTLP-derived metrics.
-func createTokenMetrics(ts time.Time, model, tokenType string, value float64) []api.MetricDataPoint {
+func createTokenMetrics(ts time.Time, model, tokenType string, value float64, meta claudeSessionMeta, repository string) []api.MetricDataPoint {
 	return []api.MetricDataPoint{
-		createTokenMetric(ts, claudeTokenUsageMetric, model, tokenType, value),
-		createTokenMetric(ts, claudeUserFacingTokenUsageMetric, model, tokenType, value),
+		createTokenMetric(ts, claudeTokenUsageMetric, model, tokenType, value, meta, repository),
+		createTokenMetric(ts, claudeUserFacingTokenUsageMetric, model, tokenType, value, meta, repository),
 	}
 }
 
 // createCostMetric creates a cost metric with the specified name
-func createCostMetric(ts time.Time, metricName, model string, value float64) api.MetricDataPoint {
+func createCostMetric(ts time.Time, metricName, model string, value float64, meta claudeSessionMeta, repository string) api.MetricDataPoint {
+	attrs := sessionAttrs(meta, repository)
+	attrs["model"] = model
+	attrs["import_source"] = "local_jsonl"
 	return api.MetricDataPoint{
 		Timestamp:   ts,
 		ServiceName: SourceClaude.ServiceName(),
 		MetricName:  metricName,
 		MetricType:  "sum",
 		Value:       &value,
-		Attributes: map[string]string{
-			"model":         model,
-			"import_source": "local_jsonl",
-		},
+		Attributes:  attrs,
 	}
 }
 
 // createCostMetrics creates both regular and user-facing cost metrics.
-// JSONL data is already user-facing (only assistant messages with cache tokens),
-// so both metrics have identical values for consistency with OTLP-derived metrics.
-func createCostMetrics(ts time.Time, model string, value float64) []api.MetricDataPoint {
+func createCostMetrics(ts time.Time, model string, value float64, meta claudeSessionMeta, repository string) []api.MetricDataPoint {
 	return []api.MetricDataPoint{
-		createCostMetric(ts, claudeCostMetric, model, value),
-		createCostMetric(ts, claudeUserFacingCostMetric, model, value),
+		createCostMetric(ts, claudeCostMetric, model, value, meta, repository),
+		createCostMetric(ts, claudeUserFacingCostMetric, model, value, meta, repository),
+	}
+}
+
+// createLOCMetric creates a lines_of_code metric for a file edit
+func createLOCMetric(ts time.Time, lineType, filePath, fileType string, value float64, meta claudeSessionMeta, repository string) api.MetricDataPoint {
+	attrs := sessionAttrs(meta, repository)
+	attrs["type"] = lineType
+	attrs["file_type"] = fileType
+	attrs["file_path"] = filePath
+	attrs["import_source"] = "local_jsonl"
+	return api.MetricDataPoint{
+		Timestamp:   ts,
+		ServiceName: SourceClaude.ServiceName(),
+		MetricName:  claudeLinesOfCodeMetric,
+		MetricType:  "sum",
+		Value:       &value,
+		Attributes:  attrs,
+	}
+}
+
+// createPRMetric creates a pull_request.count metric for a linked PR
+func createPRMetric(meta claudeSessionMeta, repository string) api.MetricDataPoint {
+	one := 1.0
+	attrs := sessionAttrs(meta, repository)
+	attrs["pr_number"] = strconv.Itoa(meta.PRNumber)
+	attrs["pr_url"] = meta.PRUrl
+	attrs["import_source"] = "local_jsonl"
+	return api.MetricDataPoint{
+		Timestamp:   meta.PRTimestamp,
+		ServiceName: SourceClaude.ServiceName(),
+		MetricName:  claudePullRequestMetric,
+		MetricType:  "sum",
+		Value:       &one,
+		Attributes:  attrs,
+	}
+}
+
+// createCommitMetric creates a commit.count metric for a git commit tool call
+func createCommitMetric(ts time.Time, meta claudeSessionMeta, repository string) api.MetricDataPoint {
+	one := 1.0
+	attrs := sessionAttrs(meta, repository)
+	attrs["import_source"] = "local_jsonl"
+	return api.MetricDataPoint{
+		Timestamp:   ts,
+		ServiceName: SourceClaude.ServiceName(),
+		MetricName:  claudeCommitMetric,
+		MetricType:  "sum",
+		Value:       &one,
+		Attributes:  attrs,
+	}
+}
+
+// createSessionMetric creates a session.count metric (one per JSONL file)
+func createSessionMetric(ts time.Time, meta claudeSessionMeta, repository string) api.MetricDataPoint {
+	one := 1.0
+	attrs := sessionAttrs(meta, repository)
+	attrs["import_source"] = "local_jsonl"
+	return api.MetricDataPoint{
+		Timestamp:   ts,
+		ServiceName: SourceClaude.ServiceName(),
+		MetricName:  claudeSessionMetric,
+		MetricType:  "sum",
+		Value:       &one,
+		Attributes:  attrs,
+	}
+}
+
+// createActiveTimeMetric creates an active_time.total metric from a turn_duration entry.
+// Each turn emits its own data point (consistent with OTLP telemetry).
+func createActiveTimeMetric(ts time.Time, secs float64, meta claudeSessionMeta, repository string) api.MetricDataPoint {
+	attrs := sessionAttrs(meta, repository)
+	attrs["import_source"] = "local_jsonl"
+	return api.MetricDataPoint{
+		Timestamp:   ts,
+		ServiceName: SourceClaude.ServiceName(),
+		MetricName:  claudeActiveTimeMetric,
+		MetricType:  "sum",
+		Value:       &secs,
+		Attributes:  attrs,
 	}
 }

--- a/backend/internal/importer/importer_test.go
+++ b/backend/internal/importer/importer_test.go
@@ -1031,6 +1031,103 @@ func TestClaudeParserSessionCommitActiveTime(t *testing.T) {
 	}
 }
 
+// TestClaudeParserMultiEdit tests that MultiEdit tool calls produce lines_of_code metrics
+func TestClaudeParserMultiEdit(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "claude-multiedit-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	multiEditInput := `{"file_path":"/home/user/proj/app.go","edits":[{"old_string":"line1\nline2","new_string":"line1\nline2\nline3"},{"old_string":"foo","new_string":""}]}`
+	lines := []string{
+		`{"type":"user","timestamp":"2025-01-02T10:00:00.000Z","sessionId":"s3","cwd":"/home/user/proj","message":{"role":"user","content":[{"type":"text","text":"edit"}]}}`,
+		`{"type":"assistant","timestamp":"2025-01-02T10:01:00.000Z","sessionId":"s3","requestId":"r1","message":{"id":"m1","model":"claude-sonnet-4-20250514","role":"assistant","usage":{"input_tokens":50,"output_tokens":20},"content":[{"type":"tool_use","name":"MultiEdit","input":` + multiEditInput + `}]}}`,
+	}
+
+	testFile := filepath.Join(tmpDir, "s3.jsonl")
+	if err := os.WriteFile(testFile, []byte(joinLines(lines)), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	os.Setenv("AI_OBSERVER_CLAUDE_PATH", tmpDir)
+	defer os.Unsetenv("AI_OBSERVER_CLAUDE_PATH")
+
+	parser := NewClaudeParser()
+	result, err := parser.ParseFile(context.Background(), testFile)
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+
+	var added, removed float64
+	for _, m := range result.Metrics {
+		if m.MetricName != claudeLinesOfCodeMetric {
+			continue
+		}
+		switch m.Attributes["type"] {
+		case "added":
+			added += *m.Value
+		case "removed":
+			removed += *m.Value
+		}
+		if m.Attributes["file_type"] != ".go" {
+			t.Errorf("expected file_type=.go, got %q", m.Attributes["file_type"])
+		}
+	}
+	// edit[0]: old=2 lines removed, new=3 lines added
+	// edit[1]: old=1 line removed, new=0 lines added (empty new_string)
+	if removed != 3 {
+		t.Errorf("expected 3 lines removed, got %v", removed)
+	}
+	if added != 3 {
+		t.Errorf("expected 3 lines added, got %v", added)
+	}
+}
+
+// TestClaudeParserSessionMetric tests that exactly one session metric is emitted per file
+// and that duplicate pr-link entries produce only one PR metric
+func TestClaudeParserSessionMetric(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "claude-session-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	lines := []string{
+		`{"type":"user","timestamp":"2025-01-02T10:00:00.000Z","sessionId":"s4","gitBranch":"main","cwd":"/home/user/proj","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}`,
+		// same PR linked twice — only one PR metric should be emitted
+		`{"type":"pr-link","sessionId":"s4","prNumber":99,"prUrl":"https://github.com/org/repo/pull/99","prRepository":"org/repo","timestamp":"2025-01-02T10:00:05.000Z"}`,
+		`{"type":"pr-link","sessionId":"s4","prNumber":99,"prUrl":"https://github.com/org/repo/pull/99","prRepository":"org/repo","timestamp":"2025-01-02T10:00:10.000Z"}`,
+		`{"type":"assistant","timestamp":"2025-01-02T10:01:00.000Z","sessionId":"s4","requestId":"r1","message":{"id":"m1","model":"claude-sonnet-4-20250514","role":"assistant","usage":{"input_tokens":100,"output_tokens":50},"content":[]}}`,
+	}
+
+	testFile := filepath.Join(tmpDir, "s4.jsonl")
+	if err := os.WriteFile(testFile, []byte(joinLines(lines)), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	os.Setenv("AI_OBSERVER_CLAUDE_PATH", tmpDir)
+	defer os.Unsetenv("AI_OBSERVER_CLAUDE_PATH")
+
+	parser := NewClaudeParser()
+	result, err := parser.ParseFile(context.Background(), testFile)
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+
+	counts := map[string]int{}
+	for _, m := range result.Metrics {
+		counts[m.MetricName]++
+	}
+
+	if counts[claudeSessionMetric] != 1 {
+		t.Errorf("expected 1 session metric, got %d", counts[claudeSessionMetric])
+	}
+	if counts[claudePullRequestMetric] != 1 {
+		t.Errorf("expected 1 PR metric for duplicate pr-link entries, got %d", counts[claudePullRequestMetric])
+	}
+}
+
 // TestCollectSessionMeta tests the session metadata collection first pass
 func TestCollectSessionMeta(t *testing.T) {
 	parser := NewClaudeParser()

--- a/backend/internal/importer/importer_test.go
+++ b/backend/internal/importer/importer_test.go
@@ -846,6 +846,277 @@ func TestImportUnregisteredParser(t *testing.T) {
 	}
 }
 
+// TestClaudeParserGitBranchAndPR tests that gitBranch, pr-link, and file-edit data are captured
+func TestClaudeParserGitBranchAndPR(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "claude-meta-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cwd := "/home/user/my-repo"
+
+	// Raw JSONL lines mixing entry types
+	lines := []string{
+		// user entry with gitBranch
+		`{"type":"user","timestamp":"2025-01-02T10:00:00.000Z","sessionId":"s1","gitBranch":"feat/my-branch","cwd":"` + cwd + `","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}`,
+		// pr-link entry (no message field)
+		`{"type":"pr-link","sessionId":"s1","prNumber":42,"prUrl":"https://github.com/org/repo/pull/42","prRepository":"org/repo","timestamp":"2025-01-02T10:00:30.000Z"}`,
+		// assistant entry with usage and an Edit tool call
+		`{"type":"assistant","timestamp":"2025-01-02T10:01:00.000Z","sessionId":"s1","requestId":"r1","gitBranch":"feat/my-branch","message":{"id":"m1","model":"claude-sonnet-4-20250514","role":"assistant","usage":{"input_tokens":100,"output_tokens":50},"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/home/user/my-repo/main.go","old_string":"line1\nline2","new_string":"line1\nline2\nline3"}}]}}`,
+		// assistant entry with a Write tool call
+		`{"type":"assistant","timestamp":"2025-01-02T10:02:00.000Z","sessionId":"s1","requestId":"r2","gitBranch":"feat/my-branch","message":{"id":"m2","model":"claude-sonnet-4-20250514","role":"assistant","usage":{"input_tokens":50,"output_tokens":20},"content":[{"type":"tool_use","name":"Write","input":{"file_path":"/home/user/my-repo/README.md","content":"# Title\nLine two\nLine three\n"}}]}}`,
+	}
+
+	testFile := filepath.Join(tmpDir, "s1.jsonl")
+	if err := os.WriteFile(testFile, []byte(joinLines(lines)), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	os.Setenv("AI_OBSERVER_CLAUDE_PATH", tmpDir)
+	defer os.Unsetenv("AI_OBSERVER_CLAUDE_PATH")
+
+	parser := NewClaudeParser()
+	ctx := context.Background()
+	result, err := parser.ParseFile(ctx, testFile)
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+
+	// Verify PR metric was emitted
+	var prMetrics []api.MetricDataPoint
+	var locMetrics []api.MetricDataPoint
+	for _, m := range result.Metrics {
+		switch m.MetricName {
+		case claudePullRequestMetric:
+			prMetrics = append(prMetrics, m)
+		case claudeLinesOfCodeMetric:
+			locMetrics = append(locMetrics, m)
+		}
+	}
+
+	if len(prMetrics) != 1 {
+		t.Errorf("expected 1 PR metric, got %d", len(prMetrics))
+	} else {
+		pr := prMetrics[0]
+		if pr.Attributes["pr_number"] != "42" {
+			t.Errorf("expected pr_number=42, got %s", pr.Attributes["pr_number"])
+		}
+		if pr.Attributes["repository"] != "org/repo" {
+			t.Errorf("expected repository=org/repo, got %s", pr.Attributes["repository"])
+		}
+		if pr.Attributes["git_branch"] != "feat/my-branch" {
+			t.Errorf("expected git_branch=feat/my-branch, got %s", pr.Attributes["git_branch"])
+		}
+	}
+
+	// Verify lines_of_code metrics:
+	// Edit: old_string has 2 lines (removed), new_string has 3 lines (added)
+	// Write: content has 4 lines (added, counting trailing newline as +1 line)
+	var locByType = map[string]float64{}
+	var locFileTypes = map[string]bool{}
+	for _, m := range locMetrics {
+		locByType[m.Attributes["type"]] += *m.Value
+		locFileTypes[m.Attributes["file_type"]] = true
+	}
+	if locByType["removed"] != 2 {
+		t.Errorf("expected 2 lines removed, got %v", locByType["removed"])
+	}
+	if locByType["added"] != 7 { // 3 from Edit + 4 from Write
+		t.Errorf("expected 7 lines added, got %v", locByType["added"])
+	}
+	if !locFileTypes[".go"] {
+		t.Error("expected .go file type in loc metrics")
+	}
+	if !locFileTypes[".md"] {
+		t.Error("expected .md file type in loc metrics")
+	}
+
+	// Verify git_branch on token metrics
+	for _, m := range result.Metrics {
+		if m.MetricName == claudeTokenUsageMetric {
+			if m.Attributes["git_branch"] != "feat/my-branch" {
+				t.Errorf("expected git_branch on token metric, got %q", m.Attributes["git_branch"])
+			}
+			if m.Attributes["repository"] != "org/repo" {
+				t.Errorf("expected repository on token metric, got %q", m.Attributes["repository"])
+			}
+			break
+		}
+	}
+
+	// Verify pr_number appears in transcript log attributes
+	for _, log := range result.Logs {
+		if log.LogAttributes["event.name"] == "transcript.message" {
+			if log.LogAttributes["pr_number"] != "42" {
+				t.Errorf("expected pr_number=42 in log attributes, got %q", log.LogAttributes["pr_number"])
+			}
+			break
+		}
+	}
+}
+
+// TestClaudeParserSessionCommitActiveTime tests session, commit, and active time metric generation
+func TestClaudeParserSessionCommitActiveTime(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "claude-sca-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	lines := []string{
+		// user entry (session starts)
+		`{"type":"user","timestamp":"2025-01-02T10:00:00.000Z","sessionId":"s2","gitBranch":"main","cwd":"/home/user/proj","message":{"role":"user","content":[{"type":"text","text":"do stuff"}]}}`,
+		// assistant with a git commit bash call
+		`{"type":"assistant","timestamp":"2025-01-02T10:01:00.000Z","sessionId":"s2","requestId":"r1","gitBranch":"main","message":{"id":"m1","model":"claude-sonnet-4-20250514","role":"assistant","usage":{"input_tokens":100,"output_tokens":50},"content":[{"type":"tool_use","name":"Bash","input":{"command":"git add . && git commit -m \"feat: add thing\""}}]}}`,
+		// another assistant with two git commits in separate tool calls
+		`{"type":"assistant","timestamp":"2025-01-02T10:02:00.000Z","sessionId":"s2","requestId":"r2","gitBranch":"main","message":{"id":"m2","model":"claude-sonnet-4-20250514","role":"assistant","usage":{"input_tokens":50,"output_tokens":20},"content":[{"type":"tool_use","name":"Bash","input":{"command":"git commit -m \"fix: typo\""}},{"type":"tool_use","name":"Bash","input":{"command":"echo hello"}}]}}`,
+		// system/turn_duration entries
+		`{"type":"system","subtype":"turn_duration","durationMs":30000,"timestamp":"2025-01-02T10:01:30.000Z","sessionId":"s2","gitBranch":"main","cwd":"/home/user/proj"}`,
+		`{"type":"system","subtype":"turn_duration","durationMs":15000,"timestamp":"2025-01-02T10:02:15.000Z","sessionId":"s2","gitBranch":"main","cwd":"/home/user/proj"}`,
+	}
+
+	testFile := filepath.Join(tmpDir, "s2.jsonl")
+	if err := os.WriteFile(testFile, []byte(joinLines(lines)), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	os.Setenv("AI_OBSERVER_CLAUDE_PATH", tmpDir)
+	defer os.Unsetenv("AI_OBSERVER_CLAUDE_PATH")
+
+	parser := NewClaudeParser()
+	ctx := context.Background()
+	result, err := parser.ParseFile(ctx, testFile)
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+
+	counts := map[string]int{}
+	var totalActiveSecs float64
+	for _, m := range result.Metrics {
+		counts[m.MetricName]++
+		if m.MetricName == claudeActiveTimeMetric && m.Value != nil {
+			totalActiveSecs += *m.Value
+		}
+	}
+
+	// One session metric per file
+	if counts[claudeSessionMetric] != 1 {
+		t.Errorf("expected 1 session metric, got %d", counts[claudeSessionMetric])
+	}
+
+	// Two commits: one from r1, one from r2 (the echo call is not a commit)
+	if counts[claudeCommitMetric] != 2 {
+		t.Errorf("expected 2 commit metrics, got %d", counts[claudeCommitMetric])
+	}
+
+	// Two turn_duration entries → two active_time metrics, total 45s
+	if counts[claudeActiveTimeMetric] != 2 {
+		t.Errorf("expected 2 active_time metrics, got %d", counts[claudeActiveTimeMetric])
+	}
+	if totalActiveSecs != 45.0 {
+		t.Errorf("expected 45s total active time, got %v", totalActiveSecs)
+	}
+
+	// All metrics should have git_branch and repository set
+	for _, m := range result.Metrics {
+		if m.MetricName == claudeSessionMetric || m.MetricName == claudeCommitMetric || m.MetricName == claudeActiveTimeMetric {
+			if m.Attributes["git_branch"] != "main" {
+				t.Errorf("%s: expected git_branch=main, got %q", m.MetricName, m.Attributes["git_branch"])
+			}
+			if m.Attributes["repository"] != "proj" {
+				t.Errorf("%s: expected repository=proj, got %q", m.MetricName, m.Attributes["repository"])
+			}
+		}
+	}
+}
+
+// TestCollectSessionMeta tests the session metadata collection first pass
+func TestCollectSessionMeta(t *testing.T) {
+	parser := NewClaudeParser()
+
+	lines := []string{
+		`{"type":"user","timestamp":"2025-01-01T00:00:00Z","gitBranch":"main","cwd":"/home/user/project"}`,
+		`{"type":"pr-link","prNumber":7,"prUrl":"https://github.com/a/b/pull/7","prRepository":"a/b","timestamp":"2025-01-01T00:01:00Z"}`,
+		// duplicate pr-link — should not overwrite the first
+		`{"type":"pr-link","prNumber":8,"prUrl":"https://github.com/a/b/pull/8","prRepository":"a/b","timestamp":"2025-01-01T00:02:00Z"}`,
+	}
+
+	meta := parser.collectSessionMeta(lines)
+
+	if meta.GitBranch != "main" {
+		t.Errorf("expected GitBranch=main, got %q", meta.GitBranch)
+	}
+	if meta.Cwd != "/home/user/project" {
+		t.Errorf("expected Cwd, got %q", meta.Cwd)
+	}
+	if meta.PRNumber != 7 {
+		t.Errorf("expected PRNumber=7 (first pr-link), got %d", meta.PRNumber)
+	}
+	if meta.PRRepository != "a/b" {
+		t.Errorf("expected PRRepository=a/b, got %q", meta.PRRepository)
+	}
+}
+
+// TestExtractRepository tests repository name derivation
+func TestExtractRepository(t *testing.T) {
+	tests := []struct {
+		meta     claudeSessionMeta
+		expected string
+	}{
+		{claudeSessionMeta{PRRepository: "org/repo"}, "org/repo"},
+		{claudeSessionMeta{Cwd: "/home/user/my-project"}, "my-project"},
+		{claudeSessionMeta{PRRepository: "org/repo", Cwd: "/home/user/other"}, "org/repo"}, // PR takes precedence
+		{claudeSessionMeta{}, ""},
+	}
+	for _, tc := range tests {
+		got := extractRepository(tc.meta)
+		if got != tc.expected {
+			t.Errorf("extractRepository(%+v) = %q, want %q", tc.meta, got, tc.expected)
+		}
+	}
+}
+
+// TestCountLines tests line counting
+func TestCountLines(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int
+	}{
+		{"", 0},
+		{"single line", 1},
+		{"line1\nline2", 2},
+		{"line1\nline2\nline3", 3},
+		{"line1\n", 2}, // trailing newline counts as an extra line
+	}
+	for _, tc := range tests {
+		got := countLines(tc.input)
+		if got != tc.expected {
+			t.Errorf("countLines(%q) = %d, want %d", tc.input, got, tc.expected)
+		}
+	}
+}
+
+// TestRelativeFilePath tests relative path extraction
+func TestRelativeFilePath(t *testing.T) {
+	tests := []struct {
+		filePath string
+		baseDir  string
+		expected string
+	}{
+		{"/home/user/project/main.go", "/home/user/project", "main.go"},
+		{"/home/user/project/sub/file.ts", "/home/user/project", "sub/file.ts"},
+		{"/home/user/project/main.go", "", "main.go"},
+		{"/other/path/file.py", "/home/user/project", "file.py"}, // outside base → basename
+	}
+	for _, tc := range tests {
+		got := relativeFilePath(tc.filePath, tc.baseDir)
+		if got != tc.expected {
+			t.Errorf("relativeFilePath(%q, %q) = %q, want %q", tc.filePath, tc.baseDir, got, tc.expected)
+		}
+	}
+}
+
 // Helper functions
 func floatPtr(f float64) *float64 {
 	return &f


### PR DESCRIPTION
## Summary

- **Git & PR metadata**: A first-pass scan of each JSONL file now collects `gitBranch`, `cwd`, and `pr-link` entries, then attaches `git_branch`, `repository`, `pr_number`, `pr_url` attributes to all emitted metrics and transcript logs.
- **New metrics from JSONL**: The importer now emits the full set of metrics Claude Code would have sent via OTLP — `claude_code.session.count` (once per file), `claude_code.pull_request.count` (from `pr-link` entries), `claude_code.commit.count` (from `git commit` Bash tool calls), `claude_code.active_time.total` (from `system`/`turn_duration` entries), and `claude_code.lines_of_code.count` broken down by file path and type (from `Edit`, `Write`, `MultiEdit` tool calls).
- **Test coverage**: New table-driven tests cover `MultiEdit` line counting, `session.count` emission, `pr-link` deduplication, and the `system`/`turn_duration` active-time path.

## Motivation

Previously the Claude Code JSONL importer only produced token/cost metrics and transcript logs. This left the imported data significantly less rich than live OTLP telemetry, making historical imports look sparse in the dashboard. This change closes that gap so imported sessions are indistinguishable from live sessions in the metrics views.

## Test plan

- [ ] `cd backend && go test -v ./internal/importer/...` passes
- [ ] Import a real Claude Code session directory and verify the dashboard shows session count, active time, lines-of-code, and commit/PR metrics
- [ ] Re-importing the same directory does not produce duplicate PR metrics (dedup logic in `collectSessionMeta`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)